### PR TITLE
Fix test suite JavaScript string

### DIFF
--- a/tests/test-suite.html
+++ b/tests/test-suite.html
@@ -603,7 +603,7 @@
                 category: 'security',
                 run: async () => {
                     await simulateDelay(900);
-                    const testInput = `<script>alert("XSS")</script>`;
+                    const testInput = '<script>alert("XSS")<\/script>';
                     const sanitized = testInput.replace(/<script.*?<\/script>/gi, '');
                     
                     if (sanitized !== testInput) {


### PR DESCRIPTION
## Summary
- fix the XSS test string so it doesn't prematurely close the script tag

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_687062b282c4832e9a94e4f833bc7275